### PR TITLE
Dark light theme graph (fixed)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -207,10 +207,11 @@ export default function HomeScreen() {
           paddingHorizontal: 30,
         }}
       >
+        {/*Language selector, current language text is not displayed  */}
         <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-          <Text style={dynamicStyles.languageText}>IT</Text>
+          <Text style={[dynamicStyles.languageText]}>{isEnglish && 'IT'}</Text>
           <Switch value={isEnglish} onValueChange={handleLanguageToggle} />
-          <Text style={dynamicStyles.languageText}>EN</Text>
+          <Text style={[dynamicStyles.languageText]}>{!isEnglish && 'EN'}</Text>
         </View>
 
         {/* Day/night mode switch using expo icon //////////////////////////////*/}

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -344,16 +344,18 @@ export default function HomeScreen() {
               height={240}
               yAxisSuffix=' s'
               chartConfig={{
-                backgroundColor: '#ffffff',
-                backgroundGradientFrom: '#ffffff',
-                backgroundGradientTo: '#ffffff',
+                backgroundColor: currentTheme.background,
+                backgroundGradientFrom: currentTheme.background,
+                backgroundGradientTo: currentTheme.background,
                 decimalPlaces: 2,
-                color: (opacity = 1) => `rgba(0, 0, 255, ${opacity})`,
-                labelColor: (opacity = 1) => `rgba(0, 0, 0, ${opacity})`,
+                color: (opacity = 1) =>
+                  `rgba(${currentTheme.textRGB}, ${opacity})`,
+                labelColor: (opacity = 1) =>
+                  `rgba(${currentTheme.textRGB}, ${opacity})`,
                 propsForDots: {
                   r: '0.1',
                   strokeWidth: '2',
-                  stroke: '#000',
+                  stroke: currentTheme.text,
                 },
                 style: {
                   paddingTop: '5%',

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -83,7 +83,7 @@ export default function HomeScreen() {
     input: {
       fontSize: 16,
       height: 45,
-      borderColor: '#0a7ea4',
+      borderColor: '#004aad',
       borderWidth: 1,
       borderRadius: 6,
       marginBottom: 30,
@@ -105,6 +105,11 @@ export default function HomeScreen() {
     outputText: {
       fontSize: 16,
       marginBottom: 5,
+      color: currentTheme.text,
+    },
+    resultText: {
+      fontSize: 18,
+      marginTop: 20,
       color: currentTheme.text,
     },
   };
@@ -366,7 +371,7 @@ export default function HomeScreen() {
         </View>
 
         {result.time0to100 && (
-          <Text style={styles.resultText}>
+          <Text style={dynamicStyles.resultText}>
             {t('tempo')} {result.time0to100} {t('seconds')}
           </Text>
         )}
@@ -388,10 +393,8 @@ export default function HomeScreen() {
                 backgroundGradientFrom: currentTheme.background,
                 backgroundGradientTo: currentTheme.background,
                 decimalPlaces: 2,
-                color: (opacity = 1) =>
-                  `rgba(${currentTheme.textRGB}, ${opacity})`,
-                labelColor: (opacity = 1) =>
-                  `rgba(${currentTheme.textRGB}, ${opacity})`,
+                color: (opacity = 1) => `rgba(0, 74, 173, ${opacity})`,
+                labelColor: (opacity = 1) => `rgba(0, 74, 173, ${opacity})`,
                 propsForDots: {
                   r: '0.1',
                   strokeWidth: '2',

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -90,6 +90,20 @@ export default function HomeScreen() {
     expoIcon: {
       color: currentTheme.tabIconSelected,
     },
+    additionalOutput: {
+      marginTop: 10,
+      padding: 10,
+      borderWidth: 1,
+      borderColor: '#ccc',
+      borderRadius: 5,
+      backgroundColor: currentTheme.background,
+      marginBottom: 20,
+    },
+    outputText: {
+      fontSize: 16,
+      marginBottom: 5,
+      color: currentTheme.text,
+    },
   };
 
   // function to toggle language
@@ -370,18 +384,18 @@ export default function HomeScreen() {
         )}
 
         {result.time0to100 && (
-          <View style={styles.additionalOutput}>
-            <Text style={styles.outputText}>
+          <View style={dynamicStyles.additionalOutput}>
+            <Text style={dynamicStyles.outputText}>
               {t('power_kgcv')}: {(kg / cv).toFixed(2)} CV/Kg
             </Text>
-            <Text style={styles.outputText}>
+            <Text style={dynamicStyles.outputText}>
               {t('power')}: {(cv / (kg / 1000)).toFixed(2)} CV/t
             </Text>
-            <Text style={styles.outputText}>
+            <Text style={dynamicStyles.outputText}>
               {t('acceleration')}:{' '}
               {(27.78 / parseFloat(result.time0to100)).toFixed(2)} m/s²
             </Text>
-            <Text style={styles.outputText}>
+            <Text style={dynamicStyles.outputText}>
               {t('distance')}:{' '}
               {(
                 0.5 *

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -81,6 +81,7 @@ export default function HomeScreen() {
     } as TextStyle,
 
     input: {
+      fontSize: 16,
       height: 60,
       borderColor: '#0a7ea4',
       borderWidth: 2,

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -224,11 +224,10 @@ export default function HomeScreen() {
           paddingHorizontal: 30,
         }}
       >
-        {/*Language selector, current language text is not displayed  */}
         <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-          <Text style={[dynamicStyles.languageText]}>{isEnglish && 'IT'}</Text>
+          <Text style={dynamicStyles.languageText}>IT</Text>
           <Switch value={isEnglish} onValueChange={handleLanguageToggle} />
-          <Text style={[dynamicStyles.languageText]}>{!isEnglish && 'EN'}</Text>
+          <Text style={dynamicStyles.languageText}>EN</Text>
         </View>
 
         {/* Day/night mode switch using expo icon //////////////////////////////*/}

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -82,9 +82,9 @@ export default function HomeScreen() {
 
     input: {
       fontSize: 16,
-      height: 60,
+      height: 45,
       borderColor: '#0a7ea4',
-      borderWidth: 2,
+      borderWidth: 1,
       borderRadius: 6,
       marginBottom: 30,
       paddingLeft: 10,
@@ -473,7 +473,7 @@ const styles = StyleSheet.create({
   buttonWhite: {
     backgroundColor: 'white',
     padding: 10,
-    height: 60,
+    height: 45,
     borderWidth: 1,
     borderColor: '#ccc',
     borderRadius: 50,
@@ -484,7 +484,7 @@ const styles = StyleSheet.create({
   buttonBlue: {
     backgroundColor: '#004aad',
     padding: 10,
-    height: 60,
+    height: 45,
     borderRadius: 50,
     flex: 0.45,
     alignItems: 'center',

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -218,13 +218,13 @@ export default function HomeScreen() {
           {colorScheme === 'dark' ? (
             <Feather
               name='moon'
-              size={48}
+              size={36}
               color={dynamicStyles.expoIcon.color}
             />
           ) : (
             <Feather
               name='sun'
-              size={48}
+              size={36}
               color={dynamicStyles.expoIcon.color}
             />
           )}

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -19,7 +19,7 @@ import Animated, {
   withTiming,
   Easing,
 } from 'react-native-reanimated';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { LineChart } from 'react-native-chart-kit';
 import { DarkTheme, NavigationContainer } from '@react-navigation/native';
@@ -167,6 +167,11 @@ export default function HomeScreen() {
     }
 
     setGraphData(data);
+
+    // scroll down to the graph when its generated, time delay is used to ensure graph is generated before it scrolls down
+    setTimeout(() => {
+      ref.current?.scrollToEnd();
+    }, 100);
   };
 
   // function to reset all inputs and results
@@ -185,8 +190,11 @@ export default function HomeScreen() {
   // calculation of specific power and other metrics
   const powerW = parseFloat(cv) * 735.5;
 
+  //used to scroll all the way down to reveal the graph
+  const ref = useRef<ScrollView>(null);
+
   return (
-    <ScrollView contentContainerStyle={dynamicStyles.container}>
+    <ScrollView ref={ref} contentContainerStyle={dynamicStyles.container}>
       <View style={dynamicStyles.container}>
         <View style={styles.row}>
           <Animated.View style={styles.imageContainer}>
@@ -335,6 +343,7 @@ export default function HomeScreen() {
                 color: '#ECEDEE',
                 textAlign: 'center',
                 fontWeight: 'bold',
+                fontSize: 16,
               }}
             >
               {t('calcola')}
@@ -347,6 +356,7 @@ export default function HomeScreen() {
                 color: '#004aad',
                 textAlign: 'center',
                 fontWeight: 'bold',
+                fontSize: 16,
               }}
             >
               {t('reset')}

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -69,7 +69,8 @@ export default function HomeScreen() {
       tintColor: currentTheme.icon,
     },
     label: {
-      fontSize: 16,
+      paddingBottom: 10,
+      fontSize: 18,
       fontWeight: 'bold',
       color: currentTheme.text,
     } as TextStyle,
@@ -80,10 +81,11 @@ export default function HomeScreen() {
     } as TextStyle,
 
     input: {
-      height: 40,
-      borderColor: '#ccc',
-      borderWidth: 1,
-      marginBottom: 10,
+      height: 60,
+      borderColor: '#0a7ea4',
+      borderWidth: 2,
+      borderRadius: 6,
+      marginBottom: 30,
       paddingLeft: 10,
       color: currentTheme.text,
     },
@@ -200,6 +202,7 @@ export default function HomeScreen() {
       <View
         style={{
           marginVertical: 20,
+          marginBottom: 40,
           width: '100%',
           flexDirection: 'row',
           alignItems: 'center',
@@ -326,15 +329,26 @@ export default function HomeScreen() {
         </Picker>
 
         <View style={styles.buttonContainer}>
-          <TouchableOpacity
-            style={styles.buttonWhite}
-            onPress={handleCalculate}
-          >
-            <Text>{t('calcola')}</Text>
+          <TouchableOpacity style={styles.buttonBlue} onPress={handleCalculate}>
+            <Text
+              style={{
+                color: '#ECEDEE',
+                textAlign: 'center',
+                fontWeight: 'bold',
+              }}
+            >
+              {t('calcola')}
+            </Text>
           </TouchableOpacity>
 
-          <TouchableOpacity style={styles.buttonBlue} onPress={handleReset}>
-            <Text style={{ color: 'white', textAlign: 'center' }}>
+          <TouchableOpacity style={styles.buttonWhite} onPress={handleReset}>
+            <Text
+              style={{
+                color: '#004aad',
+                textAlign: 'center',
+                fontWeight: 'bold',
+              }}
+            >
               {t('reset')}
             </Text>
           </TouchableOpacity>
@@ -448,16 +462,22 @@ const styles = StyleSheet.create({
   buttonWhite: {
     backgroundColor: 'white',
     padding: 10,
+    height: 60,
     borderWidth: 1,
     borderColor: '#ccc',
+    borderRadius: 50,
     flex: 0.45,
     alignItems: 'center',
+    justifyContent: 'center',
   },
   buttonBlue: {
     backgroundColor: '#004aad',
     padding: 10,
+    height: 60,
+    borderRadius: 50,
     flex: 0.45,
     alignItems: 'center',
+    justifyContent: 'center',
   },
   resultText: {
     fontSize: 18,

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -9,6 +9,7 @@ const tintColorDark = '#fff';
 export const Colors = {
   light: {
     text: '#11181C',
+    textRGB: '17, 24, 28',
     background: '#fff',
     tint: tintColorLight,
     icon: '#687076',
@@ -18,6 +19,7 @@ export const Colors = {
   },
   dark: {
     text: '#ECEDEE',
+    textRGB: '236, 237, 238',
     background: '#151718',
     tint: tintColorDark,
     icon: '#9BA1A6',


### PR DESCRIPTION

- [x]     Reduce the border thickness of the **input boxes** and change its color to `#004aad`.
- [x]     Decrease the height of the **input boxes** and the **Calculate** and **Reset** buttons.
- [x]     Change the color of the **sun icon** to `#004aad`.
- [x]     Restore the **chart color** to `#004aad`, as it was before.
   - note: the color change makes the chart hard to read in dark mode
- [x]     Keep the "IT - EN" language options always visible.
- [x]     Ensure that the "**0-100 Km/h Time:**" text (just above the chart) is white when the dark theme is enabled.
